### PR TITLE
Add gcompat as dependency to provide ld-linux-x86-64.so.2 library file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ONBUILD RUN apk update && \
     sync
 
 # Install OpenJDK 17
-RUN apk --no-cache add openjdk17 --repository=https://dl-cdn.alpinelinux.org/alpine/v3.17/community
+RUN apk --no-cache add openjdk17 gcompat --repository=https://dl-cdn.alpinelinux.org/alpine/v3.17/community
 ENV HOME /root
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
Hello,

We're using the image [ileap-java17-mvn](https://github.com/UKHomeOffice/ileap-java17-mvn) which uses this image as a base but having issues running mvn within that project. 

The error is showing it's missing a shared library file 'ld-linux-x86-64.so.2'. I found after searching the Alpine package repo that `gcompat` provides this file - https://pkgs.alpinelinux.org/contents?file=ld-linux-x86-64.so.2&path=&name=&branch=v3.17

I could install this package at runtime but the better fix would be to have it included within this image.

Please could you review this PR and get both images updated with this change?