### PR TITLE
Bump Alpine version to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### BUILD image
-FROM alpine:3.17.3
+FROM alpine:3.18
 
 # Update packages
 RUN apk update && \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ileap-java17
+
+Java 17 image built on Alpine 3.18 using [openjdk17](https://pkgs.alpinelinux.org/package/v3.18/community/x86_64/openjdk17) package.


### PR DESCRIPTION
As requested I've updated the dockerfile to use a newer Alpine version (3.18). This resolves any issues with CVEs due to using outdated version of Alpine.

Also added note to readme showing Alpine version now used.

I tested by building the image locally.