### PR TITLE
Add libstdc++ library to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM alpine:3.18
 
 # Update packages
 RUN apk update && \
-    apk add --upgrade apk-tools && \
+    apk add --upgrade apk-tools libstdc++ && \
     apk upgrade --available && \
     sync
 
 ONBUILD RUN apk update && \
-    apk add --upgrade apk-tools && \
+    apk add --upgrade apk-tools libstdc++ && \
     apk upgrade --available --ignore openjdk17 openjdk17-jmods openjdk17-demos openjdk17-doc java-common java-cacerts openjdk17-jre-headless openjdk17-jre openjdk17-jdk && \
     sync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ONBUILD RUN apk update && \
     sync
 
 # Install OpenJDK 17
-RUN apk --no-cache add openjdk17 gcompat --repository=https://dl-cdn.alpinelinux.org/alpine/v3.17/community
+RUN apk --no-cache add openjdk17 gcompat --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/community
 ENV HOME /root
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8


### PR DESCRIPTION
We're using the image [ileap-java17-mvn](https://github.com/UKHomeOffice/ileap-java17-mvn) which uses this image as a base but having issues running mvn within that project.

The error is showing it's missing a shared library file 'libstdc++.so.6' when using RocksDB. I found after searching the Alpine package repo that libstdc++ provides this file - https://pkgs.alpinelinux.org/contents?file=libstdc%2B%2B.so.6&path=&name=&branch=v3.18&repo=main

I also noticed the community packages are being pulled from 3.17 repo. I've updated this to 3.18.